### PR TITLE
Update attestation tutorial: add links, content

### DIFF
--- a/Attestation/TPM2_ActivateCredential.md
+++ b/Attestation/TPM2_ActivateCredential.md
@@ -10,3 +10,22 @@ otherwise `TPM2_ActivateCredential()` fails.
 
 Together with [`TPM2_MakeCredential()`](TPM2_MakeCredential.md),
 this function can be used to implement attestation protocols.
+
+## Inputs
+
+ - `TPMI_DH_OBJECT activateHandle` (e.g., handle for an AK)
+ - `TPMI_DH_OBJECT keyHandle` (e.g., handle for an EK corresponding to the EKpub encrypted to by `TPM2_MakeCredential()`)
+ - `TPM2B_ID_OBJECT credentialBlob` (output of `TPM2_MakeCredential()`)
+ - `TPM2B_ENCRYPTED_SECRET secret` (output of `TPM2_MakeCredential()`)
+
+## Outputs (success case)
+
+ - `TPM2B_DIGEST certInfo` (not necessarily a digest, but a small [digest-sized] secret that was input to `TPM2_MakeCredential()`)
+
+## References
+
+ - [TCG TPM Library part 1: Architecture, section 24](https://trustedcomputinggroup.org/wp-content/uploads/TCG_TPM2_r1p59_Part1_Architecture_pub.pdf)
+ - [TCG TPM Library part 2: Structures](https://trustedcomputinggroup.org/wp-content/uploads/TCG_TPM2_r1p59_Part2_Structures_pub.pdf)
+ - [TCG TPM Library part 3: Commands, section 12](https://trustedcomputinggroup.org/wp-content/uploads/TCG_TPM2_r1p59_Part3_Commands_pub.pdf)
+ - [TCG TPM Library part 3: Commands Code, section 12](https://trustedcomputinggroup.org/wp-content/uploads/TCG_TPM2_r1p59_Part3_Commands_code_pub.pdf)
+

--- a/Attestation/TPM2_MakeCredential.md
+++ b/Attestation/TPM2_MakeCredential.md
@@ -10,3 +10,22 @@ semantics are on the
 
 Together with [`TPM2_ActivateCredential()`](TPM2_ActivateCredential.md),
 this function can be used to implement attestation protocols.
+
+## Inputs
+
+ - `TPMI_DH_OBJECT handle` (e.g., an EKpub to encrypt to)
+ - `TPM2B_DIGEST credential` (not necessarily a digest, but a small [digest-sized] secret)
+ - `TPM2B_NAME objectName` (name of object resident on the same TPM as `handle` that `TPM2_ActivateCredential()` will check)
+
+## Outputs
+
+ - `TPM2B_ID_OBJECT credentialBlob` (ciphertext of encryption of `credential` with a secret "seed" [see below])
+ - `TPM2B_ENCRYPTED_SECRET secret` (ciphertext of encryption of a "seed" to `handle`)
+
+## References
+
+ - [TCG TPM Library part 1: Architecture, section 24](https://trustedcomputinggroup.org/wp-content/uploads/TCG_TPM2_r1p59_Part1_Architecture_pub.pdf)
+ - [TCG TPM Library part 2: Structures](https://trustedcomputinggroup.org/wp-content/uploads/TCG_TPM2_r1p59_Part2_Structures_pub.pdf)
+ - [TCG TPM Library part 3: Commands, section 13](https://trustedcomputinggroup.org/wp-content/uploads/TCG_TPM2_r1p59_Part3_Commands_pub.pdf)
+ - [TCG TPM Library part 3: Commands Code, section 13](https://trustedcomputinggroup.org/wp-content/uploads/TCG_TPM2_r1p59_Part3_Commands_code_pub.pdf)
+


### PR DESCRIPTION
This commit adds security considerations text, references, and describes `TPM2_{Make,Activate}Credential()` in more detail.